### PR TITLE
Refactor layouts to work with the new template engine

### DIFF
--- a/layouts/_partials/list.html
+++ b/layouts/_partials/list.html
@@ -1,0 +1,28 @@
+{{/*  {{ if .Params.toc }}  */}}
+{{ partial "toc.html" . }}
+{{/*  {{ end }}  */}}
+
+<!-- Section -->
+<section>
+	<article>
+		{{ partial "smallnav.html" . }}
+		<h1>{{.Title}}</h1>
+		{{.Content}}
+		<ul class="contentlist">
+			{{ range .Pages.ByWeight }}
+			<a class="" href="{{.RelPermalink}}">
+				<li class="border hovered flexH">
+					{{ if isset .Params "icon"}}
+					<img class="icon" src="{{.Params.icon}}" alt="{{.Params.alt}}">
+					{{ end }}
+					<div>
+						<h1>{{.Title}}</h1>
+						<p>{{.Params.description}}</p>
+					</div>
+				</li>
+			</a>
+			{{ end }}
+		</ul>
+		{{ partial "next-previous.html" . }}
+	</article>
+</section>

--- a/layouts/_partials/single.html
+++ b/layouts/_partials/single.html
@@ -1,0 +1,14 @@
+{{ if not (.Params.tocnav) }}
+	{{ partial "toc.html" . }}
+{{ end }}
+
+
+<!-- Section -->
+<section>
+	<article>
+		{{ partial "smallnav.html" . }}
+		<h1>{{.Title}}</h1>
+		{{.Content}}
+		{{ partial "next-previous.html" . }}
+	</article>
+</section>

--- a/layouts/list.html
+++ b/layouts/list.html
@@ -1,32 +1,3 @@
 {{define "main"}}
-
-{{/*  {{ if .Params.toc }}  */}}
-{{ partial "toc.html" . }}
-{{/*  {{ end }}  */}}
-
-<!-- Section -->
-<section>
-	<article>
-		{{ partial "smallnav.html" . }}
-		<h1>{{.Title}}</h1>
-		{{.Content}}
-		<ul class="contentlist">
-			{{ range .Pages.ByWeight }}
-			<a class="" href="{{.RelPermalink}}">
-				<li class="border hovered flexH">
-					{{ if isset .Params "icon"}}
-					<img class="icon" src="{{.Params.icon}}" alt="{{.Params.alt}}">
-					{{ end }}
-					<div>
-						<h1>{{.Title}}</h1>
-						<p>{{.Params.description}}</p>
-					</div>
-				</li>
-			</a>
-			{{ end }}
-		</ul>
-		{{ partial "next-previous.html" . }}
-	</article>
-</section>
-
+{{ partial "list.html" .}}
 {{end}}

--- a/layouts/single.html
+++ b/layouts/single.html
@@ -1,16 +1,3 @@
 {{define "main"}}
-
-{{ if not (.Params.tocnav) }}
-{{ partial "toc.html" . }}
-{{ end }}
-
-<!-- Section -->
-<section>
-	<article>
-		{{ partial "smallnav.html" . }}
-		<h1>{{.Title}}</h1>
-		{{.Content}}
-		{{ partial "next-previous.html" . }}
-	</article>
-</section>
+{{ partial "single.html" . }}
 {{end}}

--- a/layouts/tas-battle/list.html
+++ b/layouts/tas-battle/list.html
@@ -1,0 +1,19 @@
+{{ define "style" }}
+	{{ $sass := resources.Get "/scss/main_red.scss" }} 
+	{{ $style := $sass | css.Sass }}
+	<link rel="stylesheet" href="{{ $style.Permalink }}" />
+	
+	<link rel="shortcut icon" type="image/svg+xml" href="/faviconred.svg" />
+	<meta name="theme-color" content="#bc8d26">
+{{ end }}
+{{ define "logo" }}
+	<a class="logo" href="/"><img src="/images/title/PotionTitleRed.svg" alt="potion-title"></a>
+{{ end }}
+{{ define "potionicon" }}
+	<meta property="og:image" content="/icons/PotionIconRed.png">
+	<meta property="twitter:image" content="/icons/PotionIconRed.png">
+{{ end }}
+
+{{define "main"}}
+{{ partial "list.html" .}}
+{{end}}

--- a/layouts/tas-battle/single.html
+++ b/layouts/tas-battle/single.html
@@ -13,3 +13,7 @@
 	<meta property="og:image" content="/icons/PotionIconRed.png">
 	<meta property="twitter:image" content="/icons/PotionIconRed.png">
 {{ end }}
+
+{{define "main"}}
+{{ partial "single.html" . }}
+{{end}}

--- a/layouts/tas-comp/list.html
+++ b/layouts/tas-comp/list.html
@@ -1,0 +1,19 @@
+{{ define "style" }}
+	{{ $sass := resources.Get "/scss/main_green.scss" }}
+	{{ $style := $sass | css.Sass }}
+	<link rel="stylesheet" href="{{ $style.Permalink }}" />
+
+	<link rel="shortcut icon" type="image/svg+xml" href="/favicongreen.svg" />
+	<meta name="theme-color" content="#26bc62">
+{{ end }}
+{{ define "logo" }}
+	<a class="logo" href="/"><img src="/images/title/PotionTitleGreen.svg" alt="potion-title"></a>
+{{ end }}
+{{ define "potionicon" }}
+	<meta property="og:image" content="/icons/PotionIconGreen.png">
+	<meta property="twitter:image" content="/icons/PotionIconGreen.png">
+{{ end }}
+
+{{define "main"}}
+{{ partial "list.html" .}}
+{{end}}

--- a/layouts/tas-comp/single.html
+++ b/layouts/tas-comp/single.html
@@ -13,3 +13,7 @@
 	<meta property="og:image" content="/icons/PotionIconGreen.png">
 	<meta property="twitter:image" content="/icons/PotionIconGreen.png">
 {{ end }}
+
+{{define "main"}}
+{{ partial "single.html" . }}
+{{end}}


### PR DESCRIPTION
Turns out the way I've been doing it was apparently [unintended](https://discourse.gohugo.io/t/redefining-blocks-in-page-paths-outputs-a-blank-site/55456/10?u=scribble) (which explains why it sometimes didn't work)

But where there is a will, there is a way and now with a combination of block/define and partials I achieved nearly the same setup, where single and list specific code is now found in `_partials/[list|single].html`, while my styles are in the `tas-battle/[list|single].html` files