### PR TITLE
Keep images for discord invites loaded after leaving the page

### DIFF
--- a/layouts/_shortcodes/load-discordinvite.html
+++ b/layouts/_shortcodes/load-discordinvite.html
@@ -4,4 +4,4 @@
 	</div>
 	<strong>By clicking this button, you will connect to the discord servers to download the images for the invites. This might be giving you cookies!</strong>
 </div>
-<script src="/js/load-discordinvites.js"></script>
+<script src="/js/load-discordinvites.js" async defer></script>

--- a/static/js/load-discordinvites.js
+++ b/static/js/load-discordinvites.js
@@ -36,8 +36,8 @@ function loadAllInvites() {
  * @param {HTMLElement} inviteElement The element to apply the data to
  */
 function loadInvite(inviteCode, inviteElement) {
-
-	if (hasClickedDiscordLoad == "true") {
+	const isLoaded = sessionStorage.getItem(`${inviteCode}_isLoaded`);
+	if (isLoaded && isLoaded == "true") {
 		const data = {
 			id: sessionStorage.getItem(`${inviteCode}_id`),
 			name: sessionStorage.getItem(`${inviteCode}_name`),
@@ -75,6 +75,7 @@ function loadInvite(inviteCode, inviteElement) {
 			applyInviteData(inviteCode, inviteElement, data);
 
 			// Set data in session storage
+			sessionStorage.setItem(`${inviteCode}_isLoaded`, "true");
 			sessionStorage.setItem(`${inviteCode}_id`, data.id);
 			sessionStorage.setItem(`${inviteCode}_name`, data.name);
 			sessionStorage.setItem(`${inviteCode}_gicon`, data.gicon);

--- a/static/js/load-discordinvites.js
+++ b/static/js/load-discordinvites.js
@@ -1,15 +1,23 @@
+const localStorage = window.sessionStorage;
+const hasClickedDiscordLoad = localStorage.getItem("hasClickedDiscordLoad");
 
-document.getElementById("load-invite-button").addEventListener("click", function (e){
+if (hasClickedDiscordLoad) {
+	document.getElementById("load-invite-button").parentElement.style = "display: none";
 	loadAllInvites();
-	document.getElementById("load-invite-button").parentElement.style="display: none";
+}
+
+document.getElementById("load-invite-button").addEventListener("click", function (e) {
+	loadAllInvites();
+	document.getElementById("load-invite-button").parentElement.style = "display: none";
 })
 
-function loadAllInvites(){
+function loadAllInvites() {
 	const invites = document.getElementsByClassName("invite");
-	for(const element of invites){
+	for (const element of invites) {
 		const url = element.getAttribute("invite-url");
 		loadInvite(url, element);
 	}
+	localStorage.setItem("hasClickedDiscordLoad", "true");
 }
 
 /**
@@ -17,14 +25,50 @@ function loadAllInvites(){
  * @param {string} inviteUrl
  * @param {HTMLElement} inviteElement
  */
-function loadInvite(inviteUrl, inviteElement){
-	const url = 'https://discord.com/api/v10/invites/'+inviteUrl+'?with_counts=true';
+function loadInvite(inviteUrl, inviteElement) {
+
+	if (hasClickedDiscordLoad) {
+		const id = localStorage.getItem(`${inviteUrl}_id`);
+		const name = localStorage.getItem(`${inviteUrl}_name`);
+		const gicon = localStorage.getItem(`${inviteUrl}_gicon`)
+		const gsplash = localStorage.getItem(`${inviteUrl}_gsplash`)
+		const onlinecount = localStorage.getItem(`${inviteUrl}_onlinecount`)
+		const membercount = localStorage.getItem(`${inviteUrl}_membercount`)
+
+		//Create Element
+		const icon = inviteElement.getElementsByClassName("server-icon")[0];
+		const splash = inviteElement.getElementsByClassName("splash")[0];
+		const discordTitle = inviteElement.getElementsByClassName("discord-title")[0];
+		const discordOnline = inviteElement.getElementsByClassName("discord-online")[0];
+		const discordMembers = inviteElement.getElementsByClassName("discord-member")[0];
+
+		discordTitle.innerHTML = name;
+		discordOnline.innerHTML = onlinecount + " Online";
+		discordMembers.innerHTML = membercount + " Members"
+
+
+		if (gsplash != "null") {
+			splash.src = "https://cdn.discordapp.com/splashes/" + id + "/" + gsplash + ".png?size=480"
+			splash.style = "display: block";
+		}
+
+		let fileExtension = ".png";
+		if (gicon.includes("a_")) {
+			fileExtension = ".gif";
+		}
+
+		icon.src = "https://cdn.discordapp.com/icons/" + id + "/" + gicon + fileExtension + "?size=128";
+
+		return
+	}
+
+	const url = 'https://discord.com/api/v10/invites/' + inviteUrl + '?with_counts=true';
 	fetch(url)
 		.then(response => response.json())
 		.then(json => {
-			if(json.code==10006){
-				const discordTitle=inviteElement.getElementsByClassName("discord-title")[0];
-				discordTitle.innerHTML=json.message;
+			if (json.code == 10006) {
+				const discordTitle = inviteElement.getElementsByClassName("discord-title")[0];
+				discordTitle.innerHTML = json.message;
 				return;
 			}
 
@@ -39,27 +83,34 @@ function loadInvite(inviteUrl, inviteElement){
 			const name = json.guild.name;
 			const onlinecount = json.approximate_presence_count.toLocaleString();
 			const membercount = json.approximate_member_count.toLocaleString();
-		
-			let fileExtension=".png";
-			if(gicon.includes("a_")){
-				fileExtension=".gif";
+
+			let fileExtension = ".png";
+			if (gicon.includes("a_")) {
+				fileExtension = ".gif";
 			}
 
 			icon.src = "https://cdn.discordapp.com/icons/" + id + "/" + gicon + fileExtension + "?size=128";
 
-		
-			const discordTitle=inviteElement.getElementsByClassName("discord-title")[0];
-			const discordOnline=inviteElement.getElementsByClassName("discord-online")[0];
-			const discordMembers=inviteElement.getElementsByClassName("discord-member")[0];
 
-			discordTitle.innerHTML=name;
-			discordOnline.innerHTML=onlinecount+" Online";
-			discordMembers.innerHTML=membercount+" Members"
-			
-			
-			if(gsplash!=null){
-				splash.src = "https://cdn.discordapp.com/splashes/"+ id +"/"+gsplash+".png?size=480"
+			const discordTitle = inviteElement.getElementsByClassName("discord-title")[0];
+			const discordOnline = inviteElement.getElementsByClassName("discord-online")[0];
+			const discordMembers = inviteElement.getElementsByClassName("discord-member")[0];
+
+			discordTitle.innerHTML = name;
+			discordOnline.innerHTML = onlinecount + " Online";
+			discordMembers.innerHTML = membercount + " Members"
+
+
+			if (gsplash != null) {
+				splash.src = "https://cdn.discordapp.com/splashes/" + id + "/" + gsplash + ".png?size=480"
 				splash.style = "display: block";
 			}
+
+			localStorage.setItem(`${inviteUrl}_id`, id);
+			localStorage.setItem(`${inviteUrl}_name`, name);
+			localStorage.setItem(`${inviteUrl}_gicon`, gicon)
+			localStorage.setItem(`${inviteUrl}_gsplash`, gsplash)
+			localStorage.setItem(`${inviteUrl}_onlinecount`, onlinecount)
+			localStorage.setItem(`${inviteUrl}_membercount`, membercount)
 		});
-	}
+}

--- a/static/js/load-discordinvites.js
+++ b/static/js/load-discordinvites.js
@@ -1,7 +1,8 @@
-const localStorage = window.sessionStorage;
-const hasClickedDiscordLoad = localStorage.getItem("hasClickedDiscordLoad");
+const sessionStorage = window.sessionStorage;
+const hasClickedDiscordLoad = sessionStorage.getItem("hasClickedDiscordLoad");
 
-if (hasClickedDiscordLoad) {
+// Check if session storage has discord invite data
+if (hasClickedDiscordLoad == "true") {
 	document.getElementById("load-invite-button").parentElement.style = "display: none";
 	loadAllInvites();
 }
@@ -11,58 +12,47 @@ document.getElementById("load-invite-button").addEventListener("click", function
 	document.getElementById("load-invite-button").parentElement.style = "display: none";
 })
 
+/**
+ * Loads images and data from all invite elements on the page
+ */
 function loadAllInvites() {
 	const invites = document.getElementsByClassName("invite");
-	for (const element of invites) {
-		const url = element.getAttribute("invite-url");
-		loadInvite(url, element);
+	try {
+		for (const element of invites) {
+			const url = element.getAttribute("invite-url");
+			loadInvite(url, element);
+		}
+	} catch (e) {
+		// Set session storage to false on error
+		sessionStorage.setItem("hasClickedDiscordLoad", "false");
+		return;
 	}
-	localStorage.setItem("hasClickedDiscordLoad", "true");
+	sessionStorage.setItem("hasClickedDiscordLoad", "true");
 }
 
 /**
- * 
- * @param {string} inviteUrl
- * @param {HTMLElement} inviteElement
+ * Load a single invite
+ * @param {string} inviteCode The invite code of the url
+ * @param {HTMLElement} inviteElement The element to apply the data to
  */
-function loadInvite(inviteUrl, inviteElement) {
+function loadInvite(inviteCode, inviteElement) {
 
-	if (hasClickedDiscordLoad) {
-		const id = localStorage.getItem(`${inviteUrl}_id`);
-		const name = localStorage.getItem(`${inviteUrl}_name`);
-		const gicon = localStorage.getItem(`${inviteUrl}_gicon`)
-		const gsplash = localStorage.getItem(`${inviteUrl}_gsplash`)
-		const onlinecount = localStorage.getItem(`${inviteUrl}_onlinecount`)
-		const membercount = localStorage.getItem(`${inviteUrl}_membercount`)
+	if (hasClickedDiscordLoad == "true") {
+		const data = {
+			id: sessionStorage.getItem(`${inviteCode}_id`),
+			name: sessionStorage.getItem(`${inviteCode}_name`),
+			gicon: sessionStorage.getItem(`${inviteCode}_gicon`),
+			gsplash: sessionStorage.getItem(`${inviteCode}_gsplash`),
+			onlinecount: sessionStorage.getItem(`${inviteCode}_onlinecount`),
+			membercount: sessionStorage.getItem(`${inviteCode}_membercount`)
+		};
 
-		//Create Element
-		const icon = inviteElement.getElementsByClassName("server-icon")[0];
-		const splash = inviteElement.getElementsByClassName("splash")[0];
-		const discordTitle = inviteElement.getElementsByClassName("discord-title")[0];
-		const discordOnline = inviteElement.getElementsByClassName("discord-online")[0];
-		const discordMembers = inviteElement.getElementsByClassName("discord-member")[0];
+		applyInviteData(inviteCode, inviteElement, data);
 
-		discordTitle.innerHTML = name;
-		discordOnline.innerHTML = onlinecount + " Online";
-		discordMembers.innerHTML = membercount + " Members"
-
-
-		if (gsplash != "null") {
-			splash.src = "https://cdn.discordapp.com/splashes/" + id + "/" + gsplash + ".png?size=480"
-			splash.style = "display: block";
-		}
-
-		let fileExtension = ".png";
-		if (gicon.includes("a_")) {
-			fileExtension = ".gif";
-		}
-
-		icon.src = "https://cdn.discordapp.com/icons/" + id + "/" + gicon + fileExtension + "?size=128";
-
-		return
+		return;
 	}
 
-	const url = 'https://discord.com/api/v10/invites/' + inviteUrl + '?with_counts=true';
+	const url = `https://discord.com/api/v10/invites/${inviteCode}?with_counts=true`;
 	fetch(url)
 		.then(response => response.json())
 		.then(json => {
@@ -72,45 +62,59 @@ function loadInvite(inviteUrl, inviteElement) {
 				return;
 			}
 
-			//Create Element
-			const icon = inviteElement.getElementsByClassName("server-icon")[0];
-			const splash = inviteElement.getElementsByClassName("splash")[0];
+			// Getting the data
+			const data = {
+				id: json.guild.id,
+				gicon: json.guild.icon,
+				gsplash: json.guild.splash,
+				name: json.guild.name,
+				onlinecount: json.approximate_presence_count.toLocaleString(),
+				membercount: json.approximate_member_count.toLocaleString()
+			};
 
-			//Getting guild things
-			const id = json.guild.id;
-			const gicon = json.guild.icon;
-			const gsplash = json.guild.splash;
-			const name = json.guild.name;
-			const onlinecount = json.approximate_presence_count.toLocaleString();
-			const membercount = json.approximate_member_count.toLocaleString();
+			applyInviteData(inviteCode, inviteElement, data);
 
-			let fileExtension = ".png";
-			if (gicon.includes("a_")) {
-				fileExtension = ".gif";
-			}
-
-			icon.src = "https://cdn.discordapp.com/icons/" + id + "/" + gicon + fileExtension + "?size=128";
-
-
-			const discordTitle = inviteElement.getElementsByClassName("discord-title")[0];
-			const discordOnline = inviteElement.getElementsByClassName("discord-online")[0];
-			const discordMembers = inviteElement.getElementsByClassName("discord-member")[0];
-
-			discordTitle.innerHTML = name;
-			discordOnline.innerHTML = onlinecount + " Online";
-			discordMembers.innerHTML = membercount + " Members"
-
-
-			if (gsplash != null) {
-				splash.src = "https://cdn.discordapp.com/splashes/" + id + "/" + gsplash + ".png?size=480"
-				splash.style = "display: block";
-			}
-
-			localStorage.setItem(`${inviteUrl}_id`, id);
-			localStorage.setItem(`${inviteUrl}_name`, name);
-			localStorage.setItem(`${inviteUrl}_gicon`, gicon)
-			localStorage.setItem(`${inviteUrl}_gsplash`, gsplash)
-			localStorage.setItem(`${inviteUrl}_onlinecount`, onlinecount)
-			localStorage.setItem(`${inviteUrl}_membercount`, membercount)
+			// Set data in session storage
+			sessionStorage.setItem(`${inviteCode}_id`, data.id);
+			sessionStorage.setItem(`${inviteCode}_name`, data.name);
+			sessionStorage.setItem(`${inviteCode}_gicon`, data.gicon);
+			sessionStorage.setItem(`${inviteCode}_gsplash`, data.gsplash);
+			sessionStorage.setItem(`${inviteCode}_onlinecount`, data.onlinecount);
+			sessionStorage.setItem(`${inviteCode}_membercount`, data.membercount);
 		});
+}
+
+/**
+ * Applies the data to the invite element
+ * @param {string} inviteCode The invite code of the url
+ * @param {HTMLElement} inviteElement The element to apply the data to
+ * @param {Object} data The data to apply to
+ */
+function applyInviteData(inviteCode, inviteElement, data) {
+
+	// Get invite parts
+	const icon = inviteElement.getElementsByClassName("server-icon")[0];
+	const splash = inviteElement.getElementsByClassName("splash")[0];
+	const discordTitle = inviteElement.getElementsByClassName("discord-title")[0];
+	const discordOnline = inviteElement.getElementsByClassName("discord-online")[0];
+	const discordMembers = inviteElement.getElementsByClassName("discord-member")[0];
+
+	// Apply data to elements
+	discordTitle.innerHTML = data.name;
+	discordOnline.innerHTML = data.onlinecount + " Online";
+	discordMembers.innerHTML = data.membercount + " Members"
+
+	// Apply icon which may be animated in some cases.
+	let fileExtension = ".png";
+	if (data.gicon.includes("a_")) {
+		fileExtension = ".gif";
+	}
+
+	icon.src = `https://cdn.discordapp.com/icons/${data.id}/${data.gicon + fileExtension}?size=128`;
+
+	// Apply splash which may not exist on some servers
+	if (data.gsplash && data.gsplash != "null") {
+		splash.src = `https://cdn.discordapp.com/splashes/${data.id}/${data.gsplash}.png?size=480`
+		splash.style = "display: block";
+	}
 }


### PR DESCRIPTION
For https://minecrafttas.com/discord/, you can click the "Load images" button to prompt the browser to fetch the invite data from discord. This data will then be applied to all invites.

However, when you leave the page, the data has to be fetched again.

This PR stores the fetched data for each invite in the session storage, to fix this issue